### PR TITLE
Remove Secret Key from settings and Changed Key

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -25,7 +25,7 @@ load_dotenv(BASE_DIR / ".env")
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-rk)32a=-$tfiiz)uz-1w&rax89$&np9%&an=keh$krw*uypu5s'
+SECRET_KEY = os.getenv("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
This pull request makes an important security improvement by updating how the Django `SECRET_KEY` is managed in the `core/settings.py` file. Instead of hardcoding the secret key, it now pulls the value from an environment variable, which is a best practice for protecting sensitive information.

Security improvement:

* Changed `SECRET_KEY` in `core/settings.py` to use `os.getenv("SECRET_KEY")` instead of a hardcoded value, enhancing security by keeping secrets out of source control.

The key was changed due to previous exposure of the old Key